### PR TITLE
Update README.md to fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ cards;
 // => ["Ace of Spades", "Jack of Clubs", "Ace of Clubs", "Nine of Diamonds", "Three of Hearts"]
 ```
 
-Or we can remove two elements and insert four new ones as our restaurant expands its vegetarian options:
+Or we can remove two elements and insert three new ones as our restaurant expands its vegetarian options:
 ```js
 const menu = ['Jalapeno Poppers', 'Cheeseburger', 'Fish and Chips', 'French Fries', 'Onion Rings'];
 


### PR DESCRIPTION
In the following code snippet, only 3 elements were added while the document mentions 4. I corrected this four to a three.
`menu.splice(1, 2, 'Veggie Burger', 'House Salad', 'Teriyaki Tofu');`